### PR TITLE
(fix) Fix the trigger of the CD pipeline

### DIFF
--- a/.github/workflows/continuous_development.yml
+++ b/.github/workflows/continuous_development.yml
@@ -2,12 +2,15 @@ name: Publish release to PyPi
 
 on:
   pull_request:
+    types:
+      - closed
     branches:
       - master
 
 jobs:
   build:
     name: build
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source ode


### PR DESCRIPTION
Fix the error that the CD pipeline was triggered when a pull request is created or updated. 
Now the pipeline is triggered only if a pull request on the branch master is closed and merged.