### PR TITLE
(fix) Fix dependencies 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "plotly",
     "fastapi",
     "uvicorn[standard]",
-    "kaleido==0.1.0.post1",
+    "kaleido<=0.1.0.post1",
     "SALib",
     "click<=8.1.8"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "plotly",
     "fastapi",
     "uvicorn[standard]",
-    "kaleido==0.1.0post",
+    "kaleido==0.1.0post1",
     "SALib",
     "click<=8.1.8"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,13 @@ dependencies = [
     "sympy==1.12",
     "numpy==1.26.4",
     "pandas==2.0.0",
-    "pytest",
     "typer==0.15.1",
     "plotly",
     "fastapi",
     "uvicorn[standard]",
-    "kaleido",
+    "kaleido==0.1.0post",
     "SALib",
+    "click<=8.1.8"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "plotly",
     "fastapi",
     "uvicorn[standard]",
-    "kaleido==0.1.0post1",
+    "kaleido==0.1.0.post1",
     "SALib",
     "click<=8.1.8"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ typer==0.15.1
 plotly
 fastapi
 uvicorn[standard]
-kaleido==0.1.0post
+kaleido==0.1.0post1
 SALib
 hatchling
 click==8.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ typer==0.15.1
 plotly
 fastapi
 uvicorn[standard]
-kaleido==0.1.0post1
+kaleido==0.1.0.post1
 SALib
 hatchling
 click==8.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ typer==0.15.1
 plotly
 fastapi
 uvicorn[standard]
-kaleido
+kaleido==0.1.0post
 SALib
 hatchling
+click==8.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ typer==0.15.1
 plotly
 fastapi
 uvicorn[standard]
-kaleido==0.1.0.post1
+kaleido<=0.1.0.post1
 SALib
 hatchling
 click==8.1.8


### PR DESCRIPTION
Fix the version of the dependencies packages click and kaleido.
These two package newer versions were causing crashs or endless executions times.

For click, a version lower than the version 8.2.0 is needed.
For kaleido, the version 0.1.0post is needed.