### PR TITLE
(fix) Fix supported types for values for float type parameters

### DIFF
--- a/apparun/parameters.py
+++ b/apparun/parameters.py
@@ -141,21 +141,20 @@ class FloatParam(ImpactModelParam):
         return symbol_name == self.name
 
     def validate_values(self, values):
-        if isinstance(values, int):
-            values = float(values)
-        if isinstance(values, float):
+        accepted_types = (float, int, np.floating, np.integer)
+        if isinstance(values, accepted_types):
             # Single value
-            if values < self.min or values > self.max:
+            if float(values) < self.min or values > self.max:
                 raise ValueError(
                     f"Invalid value {values} for parameter {self.name}, value must be in range [{self.min}, {self.max}]"
                 )
         elif isinstance(values, list):
             # List of values
-            if any(type(value) not in [float, int] for value in values):
+            if any(not isinstance(value, accepted_types) for value in values):
                 raise TypeError(
                     f"The parameter {self.name} can only take float or int value or list of float or int values"
                 )
-            elif any(value < self.min or value > self.max for value in values):
+            elif any(float(value) < self.min or value > self.max for value in values):
                 raise ValueError(
                     f"Invalid values for parameter {self.name}, values must be in range [{self.min}, {self.max}]"
                 )

--- a/tests/functional/test_parameters_values_validation.py
+++ b/tests/functional/test_parameters_values_validation.py
@@ -4,6 +4,7 @@ This module contains the tests for the validation of the values of the parameter
 
 import os
 
+import numpy as np
 import pytest
 
 from apparun.impact_model import ImpactModel
@@ -124,3 +125,18 @@ def test_enum_not_an_option():
         )
     except ValueError:
         pass
+
+
+def test_float_valid():
+    """
+    Check no exception is raised when given valid values for a float type parameter.
+    """
+    impact_model = ImpactModel.from_yaml(impact_model_path)
+
+    # Test with a single value
+    params = {"lifespan": [1.2, 2, np.float16(2.4), np.int32(3)]}
+
+    try:
+        impact_model.validate_parameters_values(params)
+    except Exception:
+        pytest.fail("No exception should be raised for valid values")


### PR DESCRIPTION
Float type parameters can now accept numpy data types in addition to float and integer types.