### PR TITLE
(fix) Fix log system when using Appa Run as dependency

### DIFF
--- a/apparun/cli/main.py
+++ b/apparun/cli/main.py
@@ -6,7 +6,7 @@ import yaml
 from yaml import YAMLError
 
 import apparun.core
-from apparun.logger import logger
+from apparun.logger import init_logger, logger
 
 cli_app = typer.Typer()
 
@@ -105,4 +105,5 @@ def results(results_config_file_path: str):
 
 
 if __name__ == "__main__":
+    init_logger()
     cli_app()

--- a/apparun/logger.py
+++ b/apparun/logger.py
@@ -2,21 +2,29 @@ import logging
 import sys
 
 logger = logging.getLogger(__name__)
-logger.setLevel(level=logging.DEBUG)
 
-# Format the message in the logss
-formatter = logging.Formatter(
-    "{asctime} - {levelname} - {message}",
-    style="{",
-    datefmt="%Y-%m-%d %H:%M",
-)
 
-# Write the logs in a file
-file_handler = logging.FileHandler("apparun.log", mode="w", encoding="utf-8")
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
+def init_logger():
+    """
+    Init the logger so that all the logs are saved
+    in a file named apparun.log and are redirected on
+    the standard output.
+    """
+    logger.setLevel(level=logging.DEBUG)
 
-# Redirect all the logs to stdout
-stream_handler = logging.StreamHandler(sys.stdout)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
+    # Format the message in the logss
+    formatter = logging.Formatter(
+        "{asctime} - {levelname} - {message}",
+        style="{",
+        datefmt="%Y-%m-%d %H:%M",
+    )
+
+    # Write the logs in a file
+    file_handler = logging.FileHandler("apparun.log", mode="w", encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    # Redirect all the logs to stdout
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(logging.DEBUG)
+    logger.addHandler(stream_handler)


### PR DESCRIPTION
Fix the problem in Appa Run that makes it create a log file and store all the log relative to Appa Run, when used as a dependency by Appa Build.