### PR TITLE
(fix) ImpactTreeNode can use Expr as amount

### DIFF
--- a/apparun/impact_tree.py
+++ b/apparun/impact_tree.py
@@ -41,9 +41,9 @@ class ImpactTreeNode(BaseModel):
     @classmethod
     def validate_amount(cls, amount: Union[float, int, str]) -> Union[Expr, float]:
         try:
-            if isinstance(amount, (float, int)):
+            if isinstance(amount, (float, int, Expr)):
                 return amount
-            return parse_expr(amount).evalf()
+            return parse_expr(amount)
         except InvalidExpr:
             raise PydanticCustomError("float_expr", "Invalid float expression")
 


### PR DESCRIPTION
Fix the bug where a validation error was raised when a sympy expression was directly given to build an ImpactTreeNode instead of passing the expression as a string.