### PR TITLE
(fix) correct validate_expr false positives

### DIFF
--- a/apparun/expressions.py
+++ b/apparun/expressions.py
@@ -64,7 +64,7 @@ def validate_expr(expr: str) -> bool:
         "L_PAREN": ["OP", "ID", "L_PAREN", "COMMA", "FUN_ID"],
         "R_PAREN": ["NUMBER", "ID", "R_PAREN"],
         "COMMA": ["NUMBER", "ID", "R_PAREN"],
-        "OP": ["NUMBER", "ID", "R_PAREN"],
+        "OP": ["NUMBER", "ID", "L_PAREN", "R_PAREN"],
     }
 
     expr_copy = str(expr)
@@ -94,7 +94,7 @@ def validate_expr(expr: str) -> bool:
             valid = False
 
     fun_names = re.findall(tokens_patterns["FUN_ID"], expr)
-    allowed_funcs = dir(math) + dir(numpy)
+    allowed_funcs = dir(math) + dir(numpy.core) + dir(sympy.functions)
     return valid and nb_paren == 0 and all(fun in allowed_funcs for fun in fun_names)
 
 

--- a/tests/functional/test_arithmetic_expression_validation.py
+++ b/tests/functional/test_arithmetic_expression_validation.py
@@ -37,6 +37,9 @@ def test_valid_exprs():
         "3*a_",
         "3*a_1",
         "3*_a1",
+        "Abs(a)",
+        "abs(a)",
+        "1-exp(-defect_density*area)",
     ]
 
     for expr in exprs:


### PR DESCRIPTION
- `validate_expr` allows sympy functions
- `validate_expr` allows `(` before an operator (which can happen when `-1*param` is shortened to `-param`)